### PR TITLE
feat(mediasession): improve remote video initialization and reliability

### DIFF
--- a/apps/client/src/services/MediaSession.ts
+++ b/apps/client/src/services/MediaSession.ts
@@ -614,7 +614,9 @@ export default class MediaSession {
 
   private ensureRemoteVideoFlow(video: HTMLVideoElement, consumerId: string) {
     const attempt = async () => {
-      if (video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) return;
+      const hasData = video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA;
+      const isPlaying = hasData && !video.paused && !video.ended;
+      if (isPlaying) return;
       try {
         await this.safePlayVideo(video);
       } catch {}


### PR DESCRIPTION
- replace immediate play/keyframe with `ensureRemoteVideoFlow` retry mechanism
- enhance video element attributes for better cross-browser autoplay compatibility
- add `webkit-playsinline` and `disablePictureInPicture` support
- implement multiple timed attempts (0ms, 500ms, 1500ms) for play and keyframe requests